### PR TITLE
Fix issue#32, It could cause the rich text button area to disappear.

### DIFF
--- a/assets/javascripts/issue_dynamic_edit.js
+++ b/assets/javascripts/issue_dynamic_edit.js
@@ -260,7 +260,7 @@ function issueDynamicUpdate(field_name, field_value, type, cssClass){
 	    success: function(msg) {
 	    	/* get result page content (updated issue detail page with new status) */
 			
-	    	var parsed = $.parseHTML(msg);
+               var parsed = $.parseHTML(msg, true); // That it keeps script tag.
 			
 			var error = $(parsed).find("#errorExplanation");
 			
@@ -291,7 +291,7 @@ function issueDynamicUpdate(field_name, field_value, type, cssClass){
 				        xhr.setRequestHeader("authenticity_token", token);
 				    },
 				    success: function(msg) {
-				    	parsed = $.parseHTML(msg);
+				        parsed = $.parseHTML(msg, true); // That it keeps script tag.
 				    }
 				});
 


### PR DESCRIPTION
Hi llogeek,

I think the root cause is jQuery function parseHTML default skip script tag, so I set keepscript attribute to true.

[jQuery-parseHTML](https://www.w3cschool.cn/doc_jquery/jquery-jquery-parsehtml.html#jQuery-parseHTML-data-context-keepScripts)