### PR TITLE
New parameters to set specific action trigger on the pencil icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Add new elements on detailed issue page to **dynamically update issue's attribut
 
 You can set some settings by editing the file `assets/javascripts/issue_dynamic_edit_configuration_file.js`. Inside this file you'll find different variable :
 * **\_CONF\_FORCE\_HTTPS** : Will force AJAX call performed by the plugin to be done with https protocol. Use this value if you encounter some difficulties with "Mixed content" issues
-* **\_CONF\_LISTENER\_TYPE** : Choose which action will trigger the apparition of the edition block
+* **\_CONF\_LISTENER\_TYPE\_VALUE** : Choose which action will trigger the apparition of the edition block
+* **\_CONF\_LISTENER\_TYPE\_ICON** : Choose which action will trigger the apparition of the edition block when fired from the pencil icon (by default: same as **\_CONF\_LISTENER\_TYPE\_VALUE**)
 * **\_CONF\_LISTENER\_TARGET** : Choose which area will trigger the apparition of the edition block
 * **\_CONF\_EXCLUDED\_FIELD\_ID** : Choose which fields to exclude. They won't have the edit block and pencil
 

--- a/assets/javascripts/issue_dynamic_edit.js
+++ b/assets/javascripts/issue_dynamic_edit.js
@@ -2,7 +2,8 @@
  * OPTIONS DEFINED FROM CONFIGURATION FILE
  */
 var _CONF_FORCE_HTTPS = _CONF_FORCE_HTTPS || false;
-var _CONF_LISTENER_TYPE = _CONF_LISTENER_TYPE || "click";
+var _CONF_LISTENER_TYPE_VALUE = _CONF_LISTENER_TYPE_VALUE || "click";
+var _CONF_LISTENER_TYPE_ICON = _CONF_LISTENER_TYPE_ICON || "click";
 var _CONF_LISTENER_TARGET = _CONF_LISTENER_TARGET || "value";
 var _CONF_EXCLUDED_FIELD_ID = _CONF_EXCLUDED_FIELD_ID || [];
 
@@ -31,7 +32,7 @@ if (!document.getElementById(cssId)) {
 	head.appendChild(link);
 }
 
-$(document).on(_CONF_LISTENER_TYPE, function(e) {
+function editActionHandler(e) {
 	$('.issue .attributes .attribute .value').removeClass('edited');
 	// bind click to show edit block if click inside an edit box or on trigger, except button inside edit box
 	if(!$(e.target).closest('a.btn.btn-primary').length &&
@@ -55,7 +56,22 @@ $(document).on(_CONF_LISTENER_TYPE, function(e) {
 			}
 		}
 	}
-});
+}
+
+// Listen on events on a whole line for any field
+$(document).on(_CONF_LISTENER_TYPE_VALUE, editActionHandler);
+
+// If a supplementary type of event is set specifically for the dynamic edit icon,
+// add another listener for it
+if (_CONF_LISTENER_TYPE_VALUE !== _CONF_LISTENER_TYPE_ICON) {
+	$(document).on(_CONF_LISTENER_TYPE_ICON, function (e) {
+		if (!$(e.target).closest('.fa-pencil').length ||
+				!$(e.target).closest('.value').length) {
+			return;
+		}
+		editActionHandler(e);
+	});
+}
 
 function isExcluded(elmt_id) {
 	return _CONF_EXCLUDED_FIELD_ID.indexOf(elmt_id) > -1;

--- a/assets/javascripts/issue_dynamic_edit_configuration_file.js
+++ b/assets/javascripts/issue_dynamic_edit_configuration_file.js
@@ -12,11 +12,19 @@
 var _CONF_FORCE_HTTPS = false;
 
 /*
- * _CONF_LISTENER_TYPE (string)
+ * _CONF_LISTENER_TYPE_VALUE (string)
  * Choose which action will trigger the apparition of the edition block
  * Allowed values : click (default), dblclick
  */
-var _CONF_LISTENER_TYPE = "click";
+var _CONF_LISTENER_TYPE_VALUE = "click";
+
+/*
+ * _CONF_LISTENER_TYPE_ICON (string)
+ * If different from _CONF_LISTENER_TYPE_VALUE, the action set below will trigger
+ * the apparition of the edition block if it comes from the pencil icon.
+ * Allowed values : click (default), dblclick
+ */
+var _CONF_LISTENER_TYPE_ICON = _CONF_LISTENER_TYPE_VALUE;
 
 /*
  * _CONF_LISTENER_TARGET (string)


### PR DESCRIPTION
This allows, for instance, to trigger the apparition of the edition block:
* when clicking on the pencil icon,
or
* when double-clicking on the field itself

This way, it remains possible to select the field's value and to copy it to the clipboard without triggering edition block's apparition.