### PR TITLE
Math.trunc() not work in IE

### DIFF
--- a/lib/details_issue_hooks.rb
+++ b/lib/details_issue_hooks.rb
@@ -213,7 +213,7 @@ class DetailsIssueHooks < Redmine::Hook::ViewListener
           o << "<script>"
           o << "//<![CDATA[\n"
           o << "  function resizeTitleInput() {\n"
-          o << "    $('#TitleInput input')[0].size = Math.max(50, Math.trunc(window.innerWidth / 11));\n"
+          o << "    $('#TitleInput input')[0].size = Math.max(50, Math.floor(window.innerWidth / 11));\n"
           o << "  }\n"
           o << "  resizeTitleInput();\n"
           o << "  window.addEventListener('resize', resizeTitleInput);\n"


### PR DESCRIPTION
Internet Explorer not support Math.trunc() function. Because of this, changing fields does not work in IE.
Instead of a function Math.trunc(), you can use the Math.floor()
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc