### PR TITLE
fix #79: remove "display: table-row" from stylesheet .splitcontent

### DIFF
--- a/assets/stylesheets/issue_dynamic_edit.css
+++ b/assets/stylesheets/issue_dynamic_edit.css
@@ -114,10 +114,6 @@ body.controller-issues.action-show div.issue.details .attributes {
   width: 100%;
 }
 
-body.controller-issues.action-show div.issue.details .splitcontent {
-  display: table-row;
-}
-
 div.issue div.subject h3 {
 	position:relative;
 	display: inline-block;


### PR DESCRIPTION
Fix for Ticket Details Box described in Issue #79 