### PR TITLE
Added compatibility with Purplemine theme

### DIFF
--- a/assets/stylesheets/issue_dynamic_edit.css
+++ b/assets/stylesheets/issue_dynamic_edit.css
@@ -142,3 +142,13 @@ body.controller-issues.action-show .dynamicEdit .check_box_group {
 	border: 0px !important;
 	margin-bottom: 10px;
 }
+
+body.theme-Purplemine div.status.attribute > div.value >i.fa.fa-pencil.dynamicEditIcon.fa-fw {
+    position: absolute;
+    margin-left: 14px;
+    z-index: 999;
+    font-size: initial;
+    color: #000000;
+    line-height: 17.2px;
+    font-size: 14px;
+}


### PR DESCRIPTION
Default behavior is to show edit icon inside div.value that causes value element to grow. Purplemine theme (https://github.com/mrliptontea/PurpleMine2) has non-white background color set on div.value element. This leads to status text being visually not centered in colored rectangle box on issue page. This style makes i.dynamicEditIcon being rendered on the right of the div.value element for status field.