### PR TITLE
Hotfix #90: Error 422 on Related Issues

### DIFF
--- a/assets/javascripts/issue_dynamic_edit.js
+++ b/assets/javascripts/issue_dynamic_edit.js
@@ -37,6 +37,9 @@ if (_CONF_DISPLAY_EDIT_ICON === "block"){
 	$('body.controller-issues.action-show .issue.details').addClass('showPencils');
 }
 
+var token = $("meta[name=csrf-token]").attr('content');
+$('#new-relation-form').append('<input type="hidden" name="authenticity_token" value="'+token+'">');
+
 /* Generate edit block */
 var getEditFormHTML = function(attribute){
 	var formElement = $('#issue_' + attribute + "_id");


### PR DESCRIPTION
Hotfix of issue #90 relate to error 422 when create a new related issue. Fixed by adding the `csrf-token` in a hidden field of the `new-relation-form` form.

**Note:** The fix don't fix the missing headers and isn't tested in HTTPS environment, but is a quick solution (better than nothing).
