### PR TITLE
[Feature] Introduce Individual User Control of Dynamic Edit Using `[Disable Issue Dynamic Edit]` Field

### DIFF
--- a/lib/details_issue_hooks.rb
+++ b/lib/details_issue_hooks.rb
@@ -1,4 +1,5 @@
 class DetailsIssueHooks < Redmine::Hook::ViewListener
+
   def protect_against_forgery?
     false
   end
@@ -11,17 +12,23 @@ class DetailsIssueHooks < Redmine::Hook::ViewListener
   def view_layouts_base_html_head(context)
     return unless current_is_detail_page(context)
 
-    if User.current.allowed_to?(:edit_issues, context[:project])
+    is_disable_dynamic = User.current.custom_field_values.find{ |field| field.custom_field.name == 'Disable Issue Dynamic Edit' }
+
+    if is_disable_dynamic.to_s != "1" && User.current.allowed_to?(:edit_issues, context[:project])
       stylesheet_link_tag('issue_dynamic_edit.css', :plugin => :redmine_issue_dynamic_edit)
     end
+    
   end
 
   def view_layouts_base_body_bottom(context)
     return unless current_is_detail_page(context)
-
-    if User.current.allowed_to?(:edit_issues, context[:project])
+    
+    is_disable_dynamic = User.current.custom_field_values.find{ |field| field.custom_field.name == 'Disable Issue Dynamic Edit' }
+        
+    if is_disable_dynamic.to_s != "1" && User.current.allowed_to?(:edit_issues, context[:project])
       javascript_include_tag('issue_dynamic_edit_configuration_file.js', 'issue_dynamic_edit.js', :plugin => :redmine_issue_dynamic_edit)
     end
+    
   end
 
   def view_issues_show_details_bottom(context)


### PR DESCRIPTION
## Description
This feature allows administrators to add a new boolean user custom field, `[Disable Issue Dynamic Edit]`. When added, this field enables individual users to control the activation or deactivation of Dynamic Edit. If the user custom field does not exist, the behavior remains the same as before. However, when the field is added, users gain the option to make a selection.

## Additional Notes
To use this feature, administrators must:
Add a custom field `[Disable Issue Dynamic Edit]` of type Boolean.

![image](https://github.com/Ilogeek/redmine_issue_dynamic_edit/assets/48123604/f9c2735f-4f4f-42bb-8b00-ed57072c8636)
